### PR TITLE
HARM3D Imaging Capabilities in FMKS + Alternate Temperature Assignment

### DIFF
--- a/model/harm3d/coordinates.c
+++ b/model/harm3d/coordinates.c
@@ -1,0 +1,389 @@
+// Coordinate-dependent (but not radiation model-dependent) functions for ipole
+
+#include "coordinates.h"
+
+#include "geometry.h"
+
+int use_eKS_internal = 0;
+// int metric = 10;
+double a, hslope; // mks
+double poly_norm, poly_xt, poly_alpha, mks_smooth; // fmks
+double mks3R0, mks3H0, mks3MY1, mks3MY2, mks3MP0; // mks3
+
+// Coordinate parameters
+double startx[NDIM], stopx[NDIM], dx[NDIM];
+double cstartx[NDIM], cstopx[NDIM];
+double R0, Rin, Rout, Rh;
+// Tracing parameters we need independent of model
+double rmax_geo = 100.;
+double rmin_geo = 1.;
+
+double SMALL = 1e-40;
+/*
+ * Despite the name, this returns r, th coordinates for a KS or BL
+ * coordinate system (since they're equal), from a set of "modified"
+ * native coordinates X
+ * If METRIC_MINKOWSKI is set, returns spherical coordinates instead
+ */
+void bl_coord(double X[NDIM], double *r, double *th)
+{
+
+  if (metric == METRIC_MINKOWSKI) {
+    *r = X[1];
+    *th = X[2];
+    return;
+  } else if (metric == METRIC_EMINKOWSKI) {
+    *r = exp(X[1]);
+    *th = X[2];
+    return;
+  }
+
+  *r = exp(X[1]);
+
+  if (use_eKS_internal) {
+    *th = M_PI * X[2];
+  } else {
+    double y, thG, thJ;
+    switch (metric) {
+      case METRIC_EKS:
+        *th = X[2];
+        break;
+      case METRIC_MKS:
+        *th = M_PI * X[2] + ((1. - hslope) / 2.) * sin(2. * M_PI * X[2]);
+        break;
+      case METRIC_BHACMKS:
+        *th = X[2] + (hslope / 2.) * sin(2. * X[2]);
+        break;
+      case METRIC_FMKS:
+        thG = M_PI * X[2] + ((1. - hslope) / 2.) * sin(2. * M_PI * X[2]);
+        y = 2 * X[2] - 1.;
+        thJ = poly_norm * y
+            * (1. + pow(y / poly_xt, poly_alpha) / (poly_alpha + 1.)) + 0.5 * M_PI;
+        *th = thG + exp(mks_smooth * (startx[1] - X[1])) * (thJ - thG);
+        break;
+      case METRIC_MKS3:
+        *r = exp(X[1]) + mks3R0;
+        *th = (M_PI
+            * (1.
+                + 1. / tan((mks3H0 * M_PI) / 2.)
+                    * tan(
+                        mks3H0 * M_PI
+                            * (-0.5
+                                + (mks3MY1
+                                    + (pow(2., mks3MP0) * (-mks3MY1 + mks3MY2))
+                                        / pow(exp(X[1]) + mks3R0, mks3MP0))
+                                    * (1. - 2. * X[2]) + X[2])))) / 2.;
+        break;
+    }
+  }
+}
+
+void bl_to_ks(double X[NDIM], double ucon_bl[NDIM], double ucon_ks[NDIM])
+{
+  double r, th;
+  bl_coord(X, &r, &th);
+
+  double trans[NDIM][NDIM];
+  MUNULOOP
+    trans[mu][nu] = delta(mu, nu);
+
+  trans[0][1] = 2. * r / (r * r - 2. * r + a * a);
+  trans[3][1] = a / (r * r - 2. * r + a * a);
+
+  MULOOP
+    ucon_ks[mu] = 0.;
+  MUNULOOP
+    ucon_ks[mu] += trans[mu][nu] * ucon_bl[nu];
+}
+
+void ks_to_bl(double X[NDIM], double ucon_ks[NDIM], double ucon_bl[NDIM])
+{
+  double r, th;
+  bl_coord(X, &r, &th);
+
+  double trans[NDIM][NDIM], rev_trans[NDIM][NDIM];
+  MUNULOOP
+    trans[mu][nu] = delta(mu, nu);
+
+  trans[0][1] = 2. * r / (r * r - 2. * r + a * a);
+  trans[3][1] = a / (r * r - 2. * r + a * a);
+
+  invert_matrix(trans, rev_trans);
+
+  MULOOP
+    ucon_bl[mu] = 0.;
+  MUNULOOP
+    ucon_bl[mu] += rev_trans[mu][nu] * ucon_ks[nu];
+}
+
+/*
+ * returns g_{munu} at location specified by X
+ */
+void gcov_func(double X[NDIM], double gcov[NDIM][NDIM])
+{
+  double r, th;
+  bl_coord(X, &r, &th);
+
+  if (metric == METRIC_MINKOWSKI) {
+    MUNULOOP gcov[mu][nu] = 0;
+    gcov[0][0] = -1;
+    gcov[1][1] = 1;
+    gcov[2][2] = r*r;
+    gcov[3][3] = r*r*sin(th)*sin(th);
+    return;
+  } else if (metric == METRIC_EMINKOWSKI) {
+    MUNULOOP gcov[mu][nu] = 0;
+    gcov[0][0] = -1;
+    gcov[1][1] = r*r;
+    gcov[2][2] = r*r;
+    gcov[3][3] = r*r*sin(th)*sin(th);
+    return;
+  }
+
+  // compute ks metric
+  double Gcov_ks[NDIM][NDIM];
+  gcov_ks(r, th, Gcov_ks);
+
+  // convert from ks metric to mks/mmks
+  double dxdX[NDIM][NDIM];
+  set_dxdX(X, dxdX);
+
+  MUNULOOP
+  {
+    gcov[mu][nu] = 0;
+    for (int lam = 0; lam < NDIM; ++lam) {
+      for (int kap = 0; kap < NDIM; ++kap) {
+        gcov[mu][nu] += Gcov_ks[lam][kap] * dxdX[lam][mu] * dxdX[kap][nu];
+      }
+    }
+  }
+}
+
+// compute KS metric at point (r,th) in KS coordinates (cyclic in t, ph)
+inline void gcov_ks(double r, double th, double gcov[NDIM][NDIM])
+{
+  double cth = cos(th);
+  double sth = sin(th);
+
+  double s2 = sth * sth;
+  double rho2 = r * r + a * a * cth * cth;
+
+  MUNULOOP gcov[mu][nu] = 0.;
+  // Compute KS metric from KS coordinates (cyclic in t,phi)
+  gcov[0][0] = -1. + 2. * r / rho2;
+  gcov[0][1] = 2. * r / rho2;
+  gcov[0][3] = -2. * a * r * s2 / rho2;
+
+  gcov[1][0] = gcov[0][1];
+  gcov[1][1] = 1. + 2. * r / rho2;
+  gcov[1][3] = -a * s2 * (1. + 2. * r / rho2);
+
+  gcov[2][2] = rho2;
+
+  gcov[3][0] = gcov[0][3];
+  gcov[3][1] = gcov[1][3];
+  gcov[3][3] = s2 * (rho2 + a * a * s2 * (1. + 2. * r / rho2));
+}
+
+inline void gcov_bl(double r, double th, double gcov[NDIM][NDIM])
+{
+  double sth, cth, s2, a2, r2, DD, mu;
+  sth = fabs(sin(th));
+  s2 = sth * sth;
+  cth = cos(th);
+  a2 = a * a;
+  r2 = r * r;
+  DD = 1. - 2. / r + a2 / r2;
+  mu = 1. + a2 * cth * cth / r2;
+
+  MUNULOOP gcov[mu][nu] = 0.;
+  // Compute BL metric from BL coordinates
+  gcov[0][0] = -(1. - 2. / (r * mu));
+  gcov[0][3] = -2. * a * s2 / (r * mu);
+  gcov[3][0] = gcov[0][3];
+  gcov[1][1] = mu / DD;
+  gcov[2][2] = r2 * mu;
+  gcov[3][3] = r2 * sth * sth * (1. + a2 / r2 + 2. * a2 * s2 / (r2 * r * mu));
+
+}
+
+void set_dxdX(double X[NDIM], double dxdX[NDIM][NDIM])
+{
+  // Jacobian with respect to KS basis where X is given in
+  // non-KS basis
+  MUNULOOP
+    dxdX[mu][nu] = delta(mu, nu);
+
+  dxdX[1][1] = exp(X[1]); // Overridden by one case below
+
+  if (use_eKS_internal) {
+    dxdX[2][2] = M_PI;
+  } else {
+    switch (metric) {
+      case METRIC_EKS:
+        break;
+      case METRIC_MKS:
+        dxdX[2][2] = M_PI + (1 - hslope) * M_PI * cos(2. * M_PI * X[2]);
+        break;
+      case METRIC_BHACMKS:
+        dxdX[2][2] = 1 + hslope * cos(2. * X[2]);
+        break;
+      case METRIC_FMKS:
+        dxdX[2][1] = -exp(mks_smooth * (startx[1] - X[1])) * mks_smooth
+            * (
+            M_PI / 2. -
+            M_PI * X[2]
+                + poly_norm * (2. * X[2] - 1.)
+                    * (1
+                        + (pow((-1. + 2 * X[2]) / poly_xt, poly_alpha))
+                            / (1 + poly_alpha))
+                - 1. / 2. * (1. - hslope) * sin(2. * M_PI * X[2]));
+        dxdX[2][2] = M_PI + (1. - hslope) * M_PI * cos(2. * M_PI * X[2])
+            + exp(mks_smooth * (startx[1] - X[1]))
+                * (-M_PI
+                    + 2. * poly_norm
+                        * (1.
+                            + pow((2. * X[2] - 1.) / poly_xt, poly_alpha)
+                                / (poly_alpha + 1.))
+                    + (2. * poly_alpha * poly_norm * (2. * X[2] - 1.)
+                        * pow((2. * X[2] - 1.) / poly_xt, poly_alpha - 1.))
+                        / ((1. + poly_alpha) * poly_xt)
+                    - (1. - hslope) * M_PI * cos(2. * M_PI * X[2]));
+        break;
+      case METRIC_MKS3:
+        dxdX[2][1] = -(pow(2., -1. + mks3MP0) * exp(X[1]) * mks3H0 * mks3MP0
+            * (mks3MY1 - mks3MY2) * pow(M_PI, 2)
+            * pow(exp(X[1]) + mks3R0, -1 - mks3MP0) * (-1 + 2 * X[2]) * 1.
+            / tan((mks3H0 * M_PI) / 2.)
+            * pow(
+                1.
+                    / cos(
+                        mks3H0 * M_PI
+                            * (-0.5
+                                + (mks3MY1
+                                    + (pow(2, mks3MP0) * (-mks3MY1 + mks3MY2))
+                                        / pow(exp(X[1]) + mks3R0, mks3MP0))
+                                    * (1 - 2 * X[2]) + X[2])),
+                2));
+        dxdX[2][2] = (mks3H0 * pow(M_PI, 2)
+            * (1
+                - 2
+                    * (mks3MY1
+                        + (pow(2, mks3MP0) * (-mks3MY1 + mks3MY2))
+                            / pow(exp(X[1]) + mks3R0, mks3MP0))) * 1.
+            / tan((mks3H0 * M_PI) / 2.)
+            * pow(
+                1.
+                    / cos(
+                        mks3H0 * M_PI
+                            * (-0.5
+                                + (mks3MY1
+                                    + (pow(2, mks3MP0) * (-mks3MY1 + mks3MY2))
+                                        / pow(exp(X[1]) + mks3R0, mks3MP0))
+                                    * (1 - 2 * X[2]) + X[2])),
+                2)) / 2.;
+        break;
+      case METRIC_MINKOWSKI:
+        // Blank transform: just override L_11
+        dxdX[1][1] = 1.;
+        break;
+      case METRIC_EMINKOWSKI:
+        // keep radial transformation element!
+        break;
+    }
+  }
+}
+
+void set_dXdx(double X[NDIM], double dXdx[NDIM][NDIM]) {
+  double dxdX[NDIM][NDIM];
+  set_dxdX(X, dxdX);
+  invert_matrix(dxdX, dXdx);
+}
+
+void vec_to_ks(double X[NDIM], double v_nat[NDIM], double v_ks[NDIM]) {
+  double dxdX[NDIM][NDIM];
+  set_dxdX(X, dxdX);
+
+  MULOOP v_ks[mu] = 0.;
+  MUNULOOP v_ks[mu] += dxdX[mu][nu] * v_nat[nu];
+}
+
+void vec_from_ks(double X[NDIM], double v_ks[NDIM], double v_nat[NDIM]) {
+  double dXdx[NDIM][NDIM];
+  set_dXdx(X, dXdx);
+
+  MULOOP v_nat[mu] = 0.;
+  MUNULOOP v_nat[mu] += dXdx[mu][nu] * v_ks[nu];
+}
+
+/*
+ * Translate the input camera angles into a canonical Xcam in native coordinates
+ */
+void native_coord(double r, double th, double phi, double X[NDIM]) {
+  if (metric == METRIC_MINKOWSKI) {
+    X[0] = 1; X[1] = r; X[2] = th/180*M_PI; X[3] = phi/180*M_PI;
+  } else if (metric == METRIC_EMINKOWSKI) {
+    X[0] = 1; X[1] = log(r); X[2] = th/180*M_PI; X[3] = phi/180*M_PI;
+  } else {
+    double x[NDIM] = {0., r, th/180.*M_PI, phi/180.*M_PI};
+    X[0] = 0.0;
+    X[1] = log(r);
+    X[2] = root_find(x);
+    X[3] = phi/180.*M_PI;
+  }
+}
+
+/**
+ * Root-find the camera theta in native coordinates
+ * 
+ * TODO switch this to native_coord func above...
+ */
+double root_find(double X[NDIM])
+{
+  double th = X[2];
+  double tha, thb, thc;
+
+  double Xa[NDIM], Xb[NDIM], Xc[NDIM];
+  Xa[1] = log(X[1]);
+  Xa[3] = X[3];
+  Xb[1] = Xa[1];
+  Xb[3] = Xa[3];
+  Xc[1] = Xa[1];
+  Xc[3] = Xa[3];
+
+  if (X[2] < M_PI / 2.) {
+    Xa[2] = cstartx[2];
+    Xb[2] = (cstopx[2] - cstartx[2])/2 + SMALL;
+  } else {
+    Xa[2] = (cstopx[2] - cstartx[2])/2 - SMALL;
+    Xb[2] = cstopx[2];
+  }
+
+  double tol = 1.e-9;
+  tha = theta_func(Xa);
+  thb = theta_func(Xb);
+
+  // check limits first
+  if (fabs(tha-th) < tol) {
+    return Xa[2];
+  } else if (fabs(thb-th) < tol) {
+    return Xb[2];
+  }
+
+  // bisect for a bit
+  for (int i = 0; i < 1000; i++) {
+    Xc[2] = 0.5 * (Xa[2] + Xb[2]);
+    thc = theta_func(Xc);
+
+    if ((thc - th) * (thb - th) < 0.)
+      Xa[2] = Xc[2];
+    else
+      Xb[2] = Xc[2];
+
+    double err = theta_func(Xc) - th;
+    if (fabs(err) < tol)
+      break;
+  }
+
+  return Xc[2];
+}

--- a/model/harm3d/coordinates.h
+++ b/model/harm3d/coordinates.h
@@ -1,0 +1,53 @@
+#ifndef COORDINATES_H
+#define COORDINATES_H
+
+#include "definitions.h"
+
+// Poor man's enum of coordinate systems, set to match the values in parameters.h
+// Modified Kerr-Schild coordinates.  Gammie '03.
+#define METRIC_MKS MKSHARM
+// New-style BHAC MKS.  Just like MKS but with X2 in [0,pi] and hslope->(1-hslope)
+#define METRIC_BHACMKS 4
+// "Funky" MKS coordinates as defined on IL wiki, see
+// https://github.com/AFD-Illinois/docs/wiki/Coordinates
+#define METRIC_FMKS FMKS2
+// MKS3 coordinates from koral-light
+#define METRIC_MKS3 11
+// Spherical coordinates in Minkowski space
+#define METRIC_MINKOWSKI CAR
+// Exponential spherical coordinates in Minkowski space
+#define METRIC_EMINKOWSKI 5
+// eKS exponential radial coordinate; KS otherwise. note not the same 
+// as eKS_internal, which has X2 in [0, 1]
+#define METRIC_EKS 6
+
+// Coordinate parameters.  See 
+extern int use_eKS_internal;
+// extern int metric;
+extern double a, hslope; // mks
+extern double poly_norm, poly_xt, poly_alpha, mks_smooth; // fmks
+extern double mks3R0, mks3H0, mks3MY1, mks3MY2, mks3MP0; // mks3
+extern double startx[NDIM], stopx[NDIM], dx[NDIM];
+extern double cstartx[NDIM], cstopx[NDIM];
+extern double R0, Rin, Rout, Rh;
+extern double rmin_geo, rmax_geo;
+
+void bl_coord(double X[NDIM], double *r, double *th);
+void bl_to_ks(double X[NDIM], double ucon_bl[NDIM], double ucon_ks[NDIM]);
+void ks_to_bl(double X[NDIM], double ucon_ks[NDIM], double ucon_bl[NDIM]);
+void gcov_func(double X[NDIM], double gcov[NDIM][NDIM]);
+// TODO privatize these, why are they needed in models?
+void gcov_ks(double r, double th, double gcov[NDIM][NDIM]);
+void gcov_bl(double r, double th, double gcov[NDIM][NDIM]);
+
+// Internal
+void set_dxdX(double X[NDIM], double dxdX[NDIM][NDIM]);
+void set_dXdx(double X[NDIM], double dXdx[NDIM][NDIM]);
+void vec_to_ks(double X[NDIM], double v_nat[NDIM], double v_ks[NDIM]);
+void vec_from_ks(double X[NDIM], double v_ks[NDIM], double v_nat[NDIM]);
+
+// Translation to native coords
+void native_coord(double r, double th, double phi, double X[NDIM]);
+double root_find(double X[NDIM]);
+
+#endif // COORDINATES_H

--- a/model/harm3d/definitions.h
+++ b/model/harm3d/definitions.h
@@ -97,13 +97,13 @@ typedef struct Camera {
     (6) // BHAC style MKS coords          x1=log(r), x2=th/pi, and x3=phi
 #define MKSN (7) //  modified Kerr-Schild-Newman,  x1=log(r), x2=th, and x3=phi
 #define CKS (8)  //  modified Kerr-Schild-Newman,  x1=log(r), x2=th, and x3=phi
-
+#define FMKS2 (9) // HARM3D MKS with wider zones at the poles
 // Metric
 #define metric (MKSHARM)
 #if (metric == BL || metric == KS || metric == CKS)
 #define logscale (0) // Standard BL/KS coordinates; no logarithmic radius
 #elif (metric == MBL || metric == MKS || metric == MKSHARM ||                  \
-       metric == MKSBHAC || metric == MKSN)
+       metric == MKSBHAC || metric == MKSN || metric == FMKS2)
 #define logscale (1) // Modified BL/KS coordinates; logarithmic radius
 #endif
 
@@ -173,5 +173,23 @@ typedef struct Camera {
         for (int j = 0; j < DIM; j++)                                          \
             for (int k = 0; k < DIM; k++)                                      \
                 for (int l = 0; l < DIM; l++)
+
+// copied from decs.h
+#define xstr(s) str(s)
+#define str(s) #s
+#define STRLEN (2048)
+
+// Dimensions
+#define NDIM	4
+#define NIMG (5) // Stokes parameters plus faraday depth
+
+// "functions"
+#define sign(x) (((x) < 0) ? -1 : ((x) > 0))
+#define delta(x, y) ((x) == (y))
+
+// MAX and MIN were here but are both unsafe & slow. Use fmax/fmin
+
+#define MULOOP for(int mu=0;mu<NDIM;mu++)
+#define MUNULOOP for(int mu=0;mu<NDIM;mu++) for(int nu=0;nu<NDIM;nu++)
 
 #endif // DEFINITIONS_H

--- a/model/harm3d/definitions.h
+++ b/model/harm3d/definitions.h
@@ -99,7 +99,7 @@ typedef struct Camera {
 #define CKS (8)  //  modified Kerr-Schild-Newman,  x1=log(r), x2=th, and x3=phi
 #define FMKS2 (9) // HARM3D MKS with wider zones at the poles
 // Metric
-#define metric (MKSHARM)
+#define metric (FMKS2)
 #if (metric == BL || metric == KS || metric == CKS)
 #define logscale (0) // Standard BL/KS coordinates; no logarithmic radius
 #elif (metric == MBL || metric == MKS || metric == MKSHARM ||                  \

--- a/model/harm3d/geometry.c
+++ b/model/harm3d/geometry.c
@@ -1,0 +1,442 @@
+#include "geometry.h"
+
+#include "decs.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* 
+ find determinant of covariant metric gcov
+ find gcon, as numerical inverse of gcov
+ find connection, as numerical derivative of gcov
+ These routines are taken mostly out of HARM.
+ CFG 21 July 06
+ MM 11 July 17
+ */
+
+int invert_matrix(double Am[NDIM][NDIM], double Aminv[NDIM][NDIM]);
+int LU_decompose(double A[NDIM][NDIM], int permute[NDIM]);
+void LU_substitution(double A[NDIM][NDIM], double B[NDIM], int permute[NDIM]);
+
+/* assumes gcov has been set first; returns sqrt{|g|} */
+double gdet_func(double gcov[NDIM][NDIM])
+{
+  int i, j;
+  int permute[NDIM];
+  double gcovtmp[NDIM][NDIM];
+  double gdet;
+
+  for (i = 0; i < NDIM; i++) {
+    for (j = 0; j < NDIM; j++) {
+      gcovtmp[i][j] = gcov[i][j];
+    }
+  }
+  if (LU_decompose(gcovtmp, permute) != 0) {
+#if DEBUG
+    fprintf(stderr, "\nSingluar matrix in gdet_func()!\n");
+#endif
+    return -1;
+  }
+
+  gdet = 1.;
+  for (i = 0; i < NDIM; i++)
+    gdet *= gcovtmp[i][i];
+
+  return (sqrt(fabs(gdet)));
+}
+
+/* invert gcov to get gcon */
+int gcon_func(double gcov[NDIM][NDIM], double gcon[NDIM][NDIM])
+{
+  int sing = invert_matrix(gcov, gcon);
+#if DEBUG
+  if (sing) {
+    fprintf(stderr, "\nSingluar matrix in gcon_func()!\n");
+    print_matrix("gcov", gcov);
+  }
+#endif
+  return sing;
+}
+
+inline void flip_index(double ucon[NDIM], double Gcov[NDIM][NDIM], double ucov[NDIM])
+{
+
+    ucov[0] = Gcov[0][0] * ucon[0]
+  + Gcov[0][1] * ucon[1]
+  + Gcov[0][2] * ucon[2]
+  + Gcov[0][3] * ucon[3];
+    ucov[1] = Gcov[1][0] * ucon[0]
+  + Gcov[1][1] * ucon[1]
+  + Gcov[1][2] * ucon[2]
+  + Gcov[1][3] * ucon[3];
+    ucov[2] = Gcov[2][0] * ucon[0]
+  + Gcov[2][1] * ucon[1]
+  + Gcov[2][2] * ucon[2]
+  + Gcov[2][3] * ucon[3];
+    ucov[3] = Gcov[3][0] * ucon[0]
+  + Gcov[3][1] * ucon[1]
+  + Gcov[3][2] * ucon[2]
+  + Gcov[3][3] * ucon[3];
+
+    return;
+}
+
+/*
+ * Normalize input vector so that |v . v| = 1
+ * Overwrites input
+ */
+void normalize(double vcon[NDIM], double Gcov[NDIM][NDIM])
+{
+  int k, l;
+  double norm;
+
+  norm = 0.;
+  for (k = 0; k < 4; k++)
+    for (l = 0; l < 4; l++)
+      norm += vcon[k] * vcon[l] * Gcov[k][l];
+
+  norm = sqrt(fabs(norm));
+  for (k = 0; k < 4; k++)
+    vcon[k] /= norm;
+
+  return;
+}
+
+/*
+ * Normalize input vector so that |v . v| = target
+ * Overwrites input
+ */
+void normalize_to(double vcon[NDIM], double Gcov[NDIM][NDIM], double target)
+{
+  int k, l;
+  double norm;
+
+  norm = 0.;
+  for (k = 0; k < 4; k++)
+    for (l = 0; l < 4; l++)
+      norm += vcon[k] * vcon[l] * Gcov[k][l];
+
+  norm = sqrt(fabs(norm));
+  for (k = 0; k < 4; k++)
+    vcon[k] *= target/norm;
+
+  return;
+}
+
+/* normalize null vector in a tetrad frame */
+void null_normalize(double Kcon[NDIM], double fnorm)
+{
+  double inorm;
+
+  inorm =
+    sqrt(Kcon[1] * Kcon[1] + Kcon[2] * Kcon[2] + Kcon[3] * Kcon[3]);
+
+  Kcon[0] = fnorm;
+  Kcon[1] *= fnorm / inorm;
+  Kcon[2] *= fnorm / inorm;
+  Kcon[3] *= fnorm / inorm;
+}
+
+/* the completely antisymmetric symbol; not a tensor
+ in the coordinate basis */
+int levi_civita(int i, int j, int k, int l)
+{
+  int index[NDIM], n, do_sort, n_perm, val, n_swap;
+  if (i == j || i == k || i == l || j == k || j == l || k == l) {
+    return 0;
+  } else {
+    index[0] = i;
+    index[1] = j;
+    index[2] = k;
+    index[3] = l;
+    do_sort = 1;
+    n_perm = 0;
+    while (do_sort) {
+      n_swap = 0;
+      for (n = 0; n < NDIM - 1; n++) {
+        if (index[n] > index[n + 1]) {
+          n_perm++;
+          n_swap++;
+          val = index[n];
+          index[n] = index[n + 1];
+          index[n + 1] = val;
+        }
+      }
+      do_sort = n_swap;
+    }
+    return (n_perm % 2) ? -1 : 1;
+  }
+}
+
+// Coordinate functions not dependent on system
+double theta_func(double X[NDIM])
+{
+  double r, th;
+  bl_coord(X, &r, &th);
+  return th;
+}
+
+
+/*
+ invert_matrix():
+
+ Uses LU decomposition and back substitution to invert a matrix
+ A[][] and assigns the inverse to Ainv[][].  This routine does not
+ destroy the original matrix A[][].
+
+ Returns (1) if a singular matrix is found,  (0) otherwise.
+ */
+int invert_matrix(double Am[NDIM][NDIM], double Aminv[NDIM][NDIM])
+{
+
+  int i, j;
+  int n = NDIM;
+  int permute[NDIM];
+  double dxm[NDIM], Amtmp[NDIM][NDIM];
+
+  for (i = 0; i < NDIM; i++)
+    for (j = 0; j < NDIM; j++) {
+      Amtmp[i][j] = Am[i][j];
+    }
+
+  // Get the LU matrix:
+  if (LU_decompose(Amtmp, permute) != 0) {
+    //fprintf(stderr, "invert_matrix(): singular matrix encountered! \n");
+    return (1);
+  }
+
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      dxm[j] = 0.;
+    }
+    dxm[i] = 1.;
+
+    /* Solve the linear system for the i^th column of the inverse matrix: :  */
+    LU_substitution(Amtmp, dxm, permute);
+
+    for (j = 0; j < n; j++) {
+      Aminv[j][i] = dxm[j];
+    }
+
+  }
+
+  return (0);
+}
+
+/*
+ LU_decompose():
+
+ Performs a LU decomposition of the matrix A using Crout's method
+ with partial implicit pivoting.  The exact LU decomposition of the
+ matrix can be reconstructed from the resultant row-permuted form via
+ the integer array permute[]
+
+ The algorithm closely follows ludcmp.c of "Numerical Recipes
+ in C" by Press et al. 1992.
+
+ This will be used to solve the linear system  A.x = B
+
+ Returns (1) if a singular matrix is found,  (0) otherwise.
+*/
+int LU_decompose(double A[NDIM][NDIM], int permute[NDIM])
+{
+
+  const double absmin = 1.e-30; /* Value used instead of 0 for singular matrices */
+
+  //static double row_norm[NDIM];
+  double row_norm[NDIM];
+  double absmax, maxtemp;
+
+  int i, j, k, max_row;
+  int n = NDIM;
+
+  max_row = 0;
+
+  /* Find the maximum elements per row so that we can pretend later
+   we have unit-normalized each equation: */
+
+  for (i = 0; i < n; i++) {
+    absmax = 0.;
+
+    for (j = 0; j < n; j++) {
+
+      maxtemp = fabs(A[i][j]);
+
+      if (maxtemp > absmax) {
+        absmax = maxtemp;
+      }
+    }
+
+    /* Make sure that there is at least one non-zero element in this row: */
+    if (absmax == 0.) {
+      //fprintf(stderr, "LU_decompose(): row-wise singular matrix!\n");
+      return (1);
+    }
+
+    row_norm[i] = 1. / absmax; /* Set the row's normalization factor. */
+  }
+
+  /* The following the calculates the matrix composed of the sum
+   of the lower (L) tridagonal matrix and the upper (U) tridagonal
+   matrix that, when multiplied, form the original maxtrix.
+   This is what we call the LU decomposition of the maxtrix.
+   It does this by a recursive procedure, starting from the
+   upper-left, proceding down the column, and then to the next
+   column to the right.  The decomposition can be done in place
+   since element {i,j} require only those elements with {<=i,<=j}
+   which have already been computed.
+   See pg. 43-46 of "Num. Rec." for a more thorough description.
+   */
+
+  /* For each of the columns, starting from the left ... */
+  for (j = 0; j < n; j++) {
+
+    /* For each of the rows starting from the top.... */
+
+    /* Calculate the Upper part of the matrix:  i < j :   */
+    for (i = 0; i < j; i++) {
+      for (k = 0; k < i; k++) {
+        A[i][j] -= A[i][k] * A[k][j];
+      }
+    }
+
+    absmax = 0.0;
+
+    /* Calculate the Lower part of the matrix:  i <= j :   */
+
+    for (i = j; i < n; i++) {
+
+      for (k = 0; k < j; k++) {
+        A[i][j] -= A[i][k] * A[k][j];
+      }
+
+      /* Find the maximum element in the column given the implicit
+       unit-normalization (represented by row_norm[i]) of each row:
+       */
+      maxtemp = fabs(A[i][j]) * row_norm[i];
+
+      if (maxtemp >= absmax) {
+        absmax = maxtemp;
+        max_row = i;
+      }
+
+    }
+
+    /* Swap the row with the largest element (of column j) with row_j.  absmax
+     This is the partial pivoting procedure that ensures we don't divide
+     by 0 (or a small number) when we solve the linear system.
+     Also, since the procedure starts from left-right/top-bottom,
+     the pivot values are chosen from a pool involving all the elements
+     of column_j  in rows beneath row_j.  This ensures that
+     a row  is not permuted twice, which would mess things up.
+     */
+    if (max_row != j) {
+
+      /* Don't swap if it will send a 0 to the last diagonal position.
+       Note that the last column cannot pivot with any other row,
+       so this is the last chance to ensure that the last two
+       columns have non-zero diagonal elements.
+       */
+
+      if ((j == (n - 2)) && (A[j][j + 1] == 0.)) {
+        max_row = j;
+      } else {
+        for (k = 0; k < n; k++) {
+
+          maxtemp = A[j][k];
+          A[j][k] = A[max_row][k];
+          A[max_row][k] = maxtemp;
+
+        }
+
+        /* Don't forget to swap the normalization factors, too...
+         but we don't need the jth element any longer since we
+         only look at rows beneath j from here on out.
+         */
+        row_norm[max_row] = row_norm[j];
+      }
+    }
+
+    /* Set the permutation record s.t. the j^th element equals the
+     index of the row swapped with the j^th row.  Note that since
+     this is being done in successive columns, the permutation
+     vector records the successive permutations and therefore
+     index of permute[] also indexes the chronology of the
+     permutations.  E.g. permute[2] = {2,1} is an identity
+     permutation, which cannot happen here though.
+     */
+
+    permute[j] = max_row;
+
+    if (A[j][j] == 0.) {
+      A[j][j] = absmin;
+    }
+
+    /* Normalize the columns of the Lower tridiagonal part by their respective
+     diagonal element.  This is not done in the Upper part because the
+     Lower part's diagonal elements were set to 1, which can be done w/o
+     any loss of generality.
+     */
+    if (j != (n - 1)) {
+      maxtemp = 1. / A[j][j];
+
+      for (i = (j + 1); i < n; i++) {
+        A[i][j] *= maxtemp;
+      }
+    }
+
+  }
+
+  return (0);
+
+  /* End of LU_decompose() */
+
+}
+
+/*
+ LU_substitution():
+
+ Performs the forward (w/ the Lower) and backward (w/ the Upper)
+ substitutions using the LU-decomposed matrix A[][] of the original
+ matrix A' of the linear equation:  A'.x = B.  Upon entry, A[][]
+ is the LU matrix, B[] is the source vector, and permute[] is the
+ array containing order of permutations taken to the rows of the LU
+ matrix.  See LU_decompose() for further details.
+
+ Upon exit, B[] contains the solution x[], A[][] is left unchanged.
+*/
+void LU_substitution(double A[NDIM][NDIM], double B[NDIM], int permute[NDIM])
+{
+  int i, j;
+  int n = NDIM;
+  double tmpvar;
+
+  /* Perform the forward substitution using the LU matrix.
+   */
+  for (i = 0; i < n; i++) {
+
+    /* Before doing the substitution, we must first permute the
+     B vector to match the permutation of the LU matrix.
+     Since only the rows above the currrent one matter for
+     this row, we can permute one at a time.
+     */
+    tmpvar = B[permute[i]];
+    B[permute[i]] = B[i];
+    for (j = (i - 1); j >= 0; j--) {
+      tmpvar -= A[i][j] * B[j];
+    }
+    B[i] = tmpvar;
+  }
+
+  /* Perform the backward substitution using the LU matrix.
+   */
+  for (i = (n - 1); i >= 0; i--) {
+    for (j = (i + 1); j < n; j++) {
+      B[i] -= A[i][j] * B[j];
+    }
+    B[i] /= A[i][i];
+  }
+
+  /* End of LU_substitution() */
+}

--- a/model/harm3d/geometry.h
+++ b/model/harm3d/geometry.h
@@ -1,0 +1,28 @@
+/*
+ * geometry.h
+ *
+ *  Created on: Sep 9, 2019
+ *      Author: bprather
+ */
+
+#ifndef GEOMETRY_H
+#define GEOMETRY_H
+
+#define NDIM 4
+int gcon_func(double gcov[NDIM][NDIM], double gcon[NDIM][NDIM]);
+double gdet_func(double gcov[NDIM][NDIM]);
+
+void flip_index(double ucon[NDIM], double Gcov[NDIM][NDIM], double ucov[NDIM]);
+// Old names aliased
+inline void lower(double ucon[NDIM], double Gcov[NDIM][NDIM], double ucov[NDIM]) {flip_index(ucon, Gcov, ucov);};
+inline void raise(double ucov[NDIM], double Gcon[NDIM][NDIM], double ucon[NDIM]) {flip_index(ucov, Gcon, ucon);};
+
+void null_normalize(double Kcon[NDIM], double fnorm);
+void normalize(double vcon[NDIM], double gcov[NDIM][NDIM]);
+void normalize_to(double vcon[NDIM], double Gcov[NDIM][NDIM], double target);
+
+int invert_matrix(double Am[NDIM][NDIM], double Aminv[NDIM][NDIM]);
+double theta_func(double X[NDIM]);
+int levi_civita(int i, int j, int k, int l);
+
+#endif /* GEOMETRY_H */

--- a/model/harm3d/model.c
+++ b/model/harm3d/model.c
@@ -182,8 +182,8 @@ int get_fluid_params(double X[NDIM], struct GRMHD *modvar) {
 
     trat = Rhigh * b2 / (1. + b2) + Rlow / (1. + b2);
 
-    // Thetae_unit = 1. / 3. * (MPoME) / (trat + 1);
-    Thetae_unit = 2. / 3. * (MPoME) / (trat + 2);
+    Thetae_unit = 1. / 3. * (MPoME) / (trat + 1);
+    // Thetae_unit = 2. / 3. * (MPoME) / (trat + 2);
 
     (*modvar).theta_e = (uu / rho) * Thetae_unit;
 

--- a/model/harm3d/model.c
+++ b/model/harm3d/model.c
@@ -174,12 +174,21 @@ int get_fluid_params(double X[NDIM], struct GRMHD *modvar) {
     beta_trans = 1.;
     b2 = pow(beta / beta_trans, 2);
 
-    trat = 3.;
-    two_temp_gam = 0.5 * ((1. + 2. / 3. * (trat + 1.) / (trat + 2.)) + gam);
-    Th_unit = (1.4444444444 - 1.) * (PROTON_MASS / ELECTRON_MASS) / (1. + trat);
+    // trat = 3.;
+    // two_temp_gam = 0.5 * ((1. + 2. / 3. * (trat + 1.) / (trat + 2.)) + gam);
+    // Th_unit = (1.4444444444 - 1.) * (PROTON_MASS / ELECTRON_MASS) / (1. + trat);
+    double Rhigh = R_HIGH;
+    double Rlow = R_LOW;
 
-    (*modvar).theta_e =
-        (uu/rho) * (PROTON_MASS/ELECTRON_MASS) * (2/3)/(2+R);
+    trat = Rhigh * b2 / (1. + b2) + Rlow / (1. + b2);
+
+    // Thetae_unit = 1. / 3. * (MPoME) / (trat + 1);
+    Thetae_unit = 2. / 3. * (MPoME) / (trat + 2);
+
+    (*modvar).theta_e = (uu / rho) * Thetae_unit;
+
+
+    // (*modvar).theta_e =
         // (2. / 15.) * (uu / rho) * (PROTON_MASS / ELECTRON_MASS) + 1e-40;
 
 

--- a/model/harm3d/model.c
+++ b/model/harm3d/model.c
@@ -26,6 +26,7 @@ int N1, N2, N3;
 double gam;
 
 double R0, Rin, Rout, a, hslope;
+double mks_smooth, poly_xt, poly_alpha, poly_norm;
 double startx[NDIM], stopx[NDIM], dx[NDIM];
 
 double L_unit, T_unit;
@@ -57,20 +58,25 @@ void init_grmhd_data(char *fname) {
     }
 
     /* get standard HARM header */
-    fscanf(fp, "%d ", &N1);
-    fscanf(fp, "%d ", &N2);
-    fscanf(fp, "%d ", &N3);
-    fscanf(fp, "%lf ", &gam);
-    fscanf(fp, "%lf ", &a);
-    fscanf(fp, "%lf ", &dx[1]);
-    fscanf(fp, "%lf ", &dx[2]);
-    fscanf(fp, "%lf ", &dx[3]);
-    fscanf(fp, "%lf ", &startx[1]);
-    fscanf(fp, "%lf ", &startx[2]);
-    fscanf(fp, "%lf ", &startx[3]);
-    fscanf(fp, "%lf ", &hslope);
-    fscanf(fp, "%lf ", &Rin);
-    fscanf(fp, "%lf ", &Rout);
+	fscanf(fp, "%d ", &N1);
+	fscanf(fp, "%d ", &N2);
+	fscanf(fp, "%d ", &N3);
+	fscanf(fp, "%lf ", &gam);
+	fscanf(fp, "%lf ", &a);
+	fscanf(fp, "%lf ", &dx[1]);
+	fscanf(fp, "%lf ", &dx[2]);
+	fscanf(fp, "%lf ", &dx[3]);
+	fscanf(fp, "%lf ", &startx[1]);
+	fscanf(fp, "%lf ", &startx[2]);
+	fscanf(fp, "%lf ", &startx[3]);
+	fscanf(fp, "%lf ", &hslope);
+	fscanf(fp, "%lf ", &mks_smooth);
+	fscanf(fp, "%lf ", &poly_xt);
+	fscanf(fp, "%lf ", &poly_alpha);
+	fscanf(fp, "%lf ", &Rin);
+	fscanf(fp, "%lf ", &Rout);
+
+    poly_norm = 0.5*M_PI*1./(1. + 1./(poly_alpha + 1.)*1./pow(poly_xt, poly_alpha));
 
     stopx[0] = 1.;
     stopx[1] = startx[1] + N1 * dx[1];
@@ -173,7 +179,9 @@ int get_fluid_params(double X[NDIM], struct GRMHD *modvar) {
     Th_unit = (1.4444444444 - 1.) * (PROTON_MASS / ELECTRON_MASS) / (1. + trat);
 
     (*modvar).theta_e =
-        (2. / 15.) * (uu / rho) * (PROTON_MASS / ELECTRON_MASS) + 1e-40;
+        (uu/rho) * (PROTON_MASS/ELECTRON_MASS) * (2/3)/(2+R);
+        // (2. / 15.) * (uu / rho) * (PROTON_MASS / ELECTRON_MASS) + 1e-40;
+
 
 #if (DEBUG)
     if (uu < 0)

--- a/model/harm3d/model_global_vars.h
+++ b/model/harm3d/model_global_vars.h
@@ -20,6 +20,8 @@ extern int N1, N2, N3;
 extern double R_HIGH, R_LOW, gam;
 
 extern double R0, Rin, Rout, a, hslope;
+extern double mks_smooth, poly_xt, poly_alpha, poly_norm;
+
 extern double startx[NDIM], stopx[NDIM], dx[NDIM];
 
 extern double L_unit, T_unit;

--- a/python/converter_scripts/kharma-converter.py
+++ b/python/converter_scripts/kharma-converter.py
@@ -1,0 +1,42 @@
+import numpy as np
+import h5py
+import click
+import sys,os,glob
+import itertools as it
+
+programDir = os.path.dirname(os.path.realpath(__file__))
+
+@click.command()
+@click.option("--dumpfile",default = "/dev/null")
+@click.option("--outputdir",default = programDir)
+def convertFileForRaptor(dumpfile,outputdir):
+    hfp = h5py.File(dumpfile,'r')
+    with open(os.path.join(outputdir,dumpfile.split('/')[-1].replace(".h5",".txt")),"w") as fp:
+        header = hfp['header']
+        N1 = header['n1'][()]
+        N2 = header['n2'][()]
+        N3 = header['n3'][()]
+        gam = header['gam'][()]
+        a = header['a'][()]
+        dx1,dx2,dx3 = header['dx1'][()],header['dx2'][()],header['dx3'][()]
+        startx1,startx2,startx3 = header['startx1'][()],header['startx2'][()],header['startx3'][()]
+        hslope = header['hslope'][()]
+        Rin = header['r_in'][()]
+        Rout = header['r_out'][()]
+        mks_smooth = header['mks_smooth'][()]
+        poly_xt = header['poly_xt'][()]
+        poly_alpha = header['poly_alpha'][()]
+
+
+        fp.write(f"{N1} {N2} {N3} {gam} {a} {dx1} {dx2} {dx3} {startx1} \
+            {startx2} {startx3} {hslope} {mks_smooth} {poly_xt} \
+                {poly_alpha} {Rin} {Rout} \n")
+        prims = hfp['prims']
+        nprims = hfp['header']['np'][()]
+        for i,j,k in it.product(range(N1),range(N2),range(N3)):
+            for l in range(nprims):
+                fp.write(f"{prims[i,j,k,l]} ")
+            fp.write("\n")
+
+if __name__ == "__main__":
+    convertFileForRaptor()

--- a/run/makefile
+++ b/run/makefile
@@ -1,6 +1,6 @@
 CC = h5cc -I$(RAPTOR)/src -I$(PWD)
 CFLAGS = -fopenmp  -std=c99  -O2 -lm -lgsl -Wall -Wno-unused-but-set-variable
-LDFLAGS = -fopenmp -lm -lgsl 
+LDFLAGS = -fopenmp -lm -lgsl -lgslcblas
 
 VPATH=$(RAPTOR)/src:
 CPATH=$(RAPTOR)/src:
@@ -9,7 +9,7 @@ OBJDIR=build
 
 TARGET=RAPTOR
 
-SOURCES=main.c core.c io.c GRmath.c gr_integrator.c rte_integrator.c pol_rte_integrator.c metric.c pol_emission.c tetrad.c model.c constants.c camera.c
+SOURCES=main.c core.c io.c GRmath.c gr_integrator.c rte_integrator.c pol_rte_integrator.c metric.c pol_emission.c tetrad.c model.c constants.c camera.c coordinates.c geometry.c
 OBJECTS := $(patsubst %.c,$(OBJDIR)/%.o,$(SOURCES))
 
 all: create_directories $(SOURCES) $(TARGET)

--- a/run/model.in
+++ b/run/model.in
@@ -1,14 +1,14 @@
 MBH		(Msun)	4.14e6
 DISTANCE		(kpc) 8.127
-M_UNIT		(g)	1e+18
+M_UNIT		(g)	1.47053e+18
 R_LOW		(-)	1
 R_HIGH		(-)	1
 
 INCLINATION	(deg)           50
 IMG_WIDTH	(pixels)	200
 IMG_HEIGHT	(pixels)	200
-CAM_SIZE_X	(Rg)		40
-CAM_SIZE_Y	(Rg)		40
+CAM_SIZE_X	(Rg)		39.8156
+CAM_SIZE_Y	(Rg)		39.8156
 FREQS_PER_DEC	(-)		1
 FREQ_MIN	(Hz)		230.e9
 STEPSIZE	(-)		0.01

--- a/setup.sh
+++ b/setup.sh
@@ -98,6 +98,10 @@ then
     	then
 	    	sed -i  '/#define metric (/s/.*/#define metric (MKSHARM)/' definitions.h
         fi
+    	if [ "$METRIC" == "fmks" ] ;
+    	then
+	    	sed -i  '/#define metric (/s/.*/#define metric (FMKS2)/' definitions.h
+        fi
 fi
 
 if [ "$INT" == "ver" ] ;

--- a/setup.sh
+++ b/setup.sh
@@ -3,9 +3,9 @@
 echo "RAPTOR setup script"
 
 
-METRIC="cks"
+METRIC="fmks"
 INT="rk4"
-CODE="bhac"
+CODE="harm3d"
 GRID="smr"
 RAD="pol"
 SF="nosfc"

--- a/src/functions.h
+++ b/src/functions.h
@@ -134,9 +134,9 @@ void connection_udd(double X_u[4], double gamma_udd[4][4][4]);
 void initialize_photon(double alpha, double beta, double k_u[4], double t_init);
 
 // Transformation functions
-double Xg2_approx_rand(double Xr2);
+double Xg2_approx_rand(double Xr2, double Xg1);
 
-double Ug2_approx_rand(double Ur2, double Xg2);
+double Ug2_approx_rand(double Ur2, double Ug1, double Xg2, double Xg1);
 
 // TETRAD.C
 ///////////

--- a/src/metric.c
+++ b/src/metric.c
@@ -5,6 +5,7 @@
  *
  */
 #include "definitions.h"
+#include "coordinates.h"
 #include "functions.h"
 #include "global_vars.h"
 #include "model_definitions.h"
@@ -204,6 +205,58 @@ void metric_dd(double X_u[4], double g_dd[4][4]) {
                 g_dd[i][j] = f * l[i] * l[j];
         }
     }
+#elif(metric == FMKS2) //FMKS, same as MKSHARM but wider zones near pols
+
+    gcov_func(X_u, g_dd);
+//     double x1 = X_u[1];
+//     double x2 = X_u[2];
+//     double dx1 = x1 - startx[1];
+//     double polyalpha=poly_alpha,polyxt=poly_xt,polynorm=poly_norm,mkssmooth=mks_smooth;
+//     g_dd[0][0] = -1 + (2*exp(x1))/(exp(2*x1) + pow(a,2)*pow(cos(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + 
+//           (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2));
+//     g_dd[0][1] = (2*exp(2*x1))/(exp(2*x1) + pow(a,2)*pow(cos(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + 
+//          (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2));
+//     g_dd[0][2] = 0.0;
+//     g_dd[0][3] = (-2*a*exp(x1)*pow(sin(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - 
+//            ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2))/
+//    (exp(2*x1) + pow(a,2)*pow(cos(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + 
+//          (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2));
+//     g_dd[1][1] = exp(2*x1)*(1 + (2*exp(x1))/
+//        (exp(2*x1) + pow(a,2)*pow(cos(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + 
+//              (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2))) + 
+//    (pow(mkssmooth,2)*(exp(2*x1) + pow(a,2)*pow(cos(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + 
+//             (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2))*
+//       pow(M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - ((1 - hslope)*sin(2*M_PI*x2))/2.,2))/exp(2*dx1*mkssmooth);
+//     g_dd[1][2] = -((mkssmooth*(M_PI + (1 - hslope)*M_PI*cos(2*M_PI*x2) + (-M_PI + (2*polyalpha*polynorm*(-1 + 2*x2)*pow((-1 + 2*x2)/polyxt,-1 + polyalpha))/((1 + polyalpha)*polyxt) + 
+//             2*polynorm*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - (1 - hslope)*M_PI*cos(2*M_PI*x2))/exp(dx1*mkssmooth))*
+//        (exp(2*x1) + pow(a,2)*pow(cos(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + 
+//              (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2))*
+//        (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - ((1 - hslope)*sin(2*M_PI*x2))/2.))/exp(dx1*mkssmooth));
+//     g_dd[1][3] = -(a*exp(x1)*(1 + (2*exp(x1))/
+//         (exp(2*x1) + pow(a,2)*pow(cos(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + 
+//               (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2)))*
+//      pow(sin(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - 
+//            ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2));
+//     g_dd[2][2] = pow(M_PI + (1 - hslope)*M_PI*cos(2*M_PI*x2) + (-M_PI + (2*polyalpha*polynorm*(-1 + 2*x2)*pow((-1 + 2*x2)/polyxt,-1 + polyalpha))/((1 + polyalpha)*polyxt) + 
+//         2*polynorm*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - (1 - hslope)*M_PI*cos(2*M_PI*x2))/exp(dx1*mkssmooth),2)*
+//    (exp(2*x1) + pow(a,2)*pow(cos(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + 
+//          (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2));
+//     g_dd[2][3] = 0.0;
+//     g_dd[3][3] = pow(sin(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - 
+//          ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2)*(exp(2*x1) + 
+//      pow(a,2)*pow(cos(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - 
+//             ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2) + 
+//      pow(a,2)*(1 + (2*exp(x1))/
+//          (exp(2*x1) + pow(a,2)*pow(cos(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + 
+//                (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2)))*
+//       pow(sin(M_PI*x2 + ((1 - hslope)*sin(2*M_PI*x2))/2. + (M_PI/2. - M_PI*x2 + polynorm*(-1 + 2*x2)*(1 + pow((-1 + 2*x2)/polyxt,polyalpha)/(1 + polyalpha)) - 
+//             ((1 - hslope)*sin(2*M_PI*x2))/2.)/exp(dx1*mkssmooth)),2));
+
+//     for (int i=0; i<4; i++){
+//         for (int j=0;j<i;j++){
+//             g_dd[i][j] = g_dd[j][i];
+//         }
+//     }
 
 #endif
 }
@@ -292,6 +345,13 @@ void metric_uu(double X_u[4], double g_uu[4][4]) {
 
     g_uu[3][1] = g_uu[1][3];
     g_uu[3][3] = irho2 / (sin2th);
+    
+#elif(metric == FMKS2) // FMKS, similar to MKSHARM but wider zones near pole
+    double g_dd[NDIM][NDIM];
+    LOOP_ij g_dd[i][j] = 0.;
+    metric_dd(X_u,g_dd);
+    gcon_func(g_dd,g_uu);
+
 #elif (metric == MKSBHAC)
 
     double r = exp(X_u[1]);
@@ -1185,7 +1245,7 @@ void initialize_photon(double alpha, double beta, double photon_u[8],
 
 // Convert k_u to the coordinate system that is currently used
 #if (metric == KS || metric == MKS || metric == MKSHARM || metric == MKSN ||   \
-     metric == CKS || metric == MKSBHAC)
+     metric == CKS || metric == MKSBHAC || metric == FMKS2)
 
     double KSphoton_u[8];
     BL_to_KS_u(photon_u, KSphoton_u);
@@ -1196,16 +1256,40 @@ void initialize_photon(double alpha, double beta, double photon_u[8],
 
 #endif
 
-#if (metric == MKSHARM || metric == MKSBHAC)
+#if (metric == MKSHARM || metric == MKSBHAC || metric == FMKS2)
+    photon_u[2] = Xg2_approx_rand(photon_u[2], photon_u[1]); // We only transform theta - r is already exponential and R0 = 0
+    // apply transformation to photon 4velocity as given in coordinates.c, no need to root find for u^x2
+    // do this before solving for photon_x2 but after computing x2 of photon as we need x_u in FMKS
+    double dXdx[4][4];
+    LOOP_ij dXdx[i][j]=0.0;
+    double X_u[4];
+    LOOP_i X_u[i] = photon_u[i];
+    // setting k to fully KS (no log(r)) for the transformation
+    photon_u[5] *= exp(X_u[1]);
+    // printf("Before metric transformation\n");
+    // LOOP_i printf("%e %e |",X_u[i],photon_u[i+4]);
+    set_dXdx(X_u,dXdx);
+    double U_u_KS[4];
+    LOOP_i{
+        U_u_KS[i] = photon_u[i+4];
+        photon_u[i+4] = 0.0;
+    }
+    LOOP_ij{
+        photon_u[i+4]+=dXdx[i][j]*U_u_KS[j];
+    }     
 
-    photon_u[2] =
-        Xg2_approx_rand(photon_u[2]); // We only transform theta - r is
-                                      // already exponential and R0 = 0
-
-    photon_u[6] =
-        Ug2_approx_rand(photon_u[6],
-                        photon_u[2]); // We only transform theta - r is
-                                      // already exponential and R0 = 0
+    LOOP_i Xcam_u[i] = photon_u[i];
+    LOOP_i k_u[i] = photon_u[i+4];   
+    // printf("After metric transformation\n");
+    // LOOP_i printf("%e %e |",photon_u[i],photon_u[i+4]);
+    // printf("\n");
+    // if (metric != FMKS2){
+    //     LOOP_i photon_u[i+4] = U_u_KS[i];
+    //     photon_u[6] = Ug2_approx_rand(KSphoton_u[6], photon_u[5], photon_u[2], photon_u[1]); // We only transform theta - r is already exponential and R0 = 0
+    // }    
+    // printf("After root finding\n");
+    // LOOP_i printf("%e %e |",photon_u[i],photon_u[i+4]);
+    // printf("\n");
 #endif
 
 #if (metric == CKS)
@@ -1299,144 +1383,169 @@ void initialize_photon_perspective(double alpha, double beta,
 // TRANSFORMATION FUNCTIONS
 ///////////////////////////
 
-// WARNING: some of these functions are NOT listed in functions.h, and are
-// only used by other functions in this file.
+// WARNING: these are not yet listed in functions.h and are only meant for use
+// by other functions in this file.
 
 // Returns the value of f(Xg2) given some value for Xr2. For the correct Xg2,
 // we have f(Xg2) = 0.
-double f_Xg2(double Xg2, double Xr2) {
-#if (metric == MKSHARM)
-
-    return M_PI * Xg2 + 0.5 * (1. - hslope) * sin(2. * M_PI * Xg2) - Xr2;
-
-#elif (metric == MKSBHAC)
-
-    return Xg2 + 0.5 * hslope * sin(2. * Xg2) - Xr2;
-
-#endif
-
-    return -1;
+double f_Xg2(double Xg2, double Xr2, double Xg1)
+{
+	if (metric == MKSHARM)
+		return M_PI * Xg2 + 0.5 * (1. - hslope) * sin(2. * M_PI * Xg2) - Xr2;
+	else if (metric == FMKS2)
+	{
+		double th_g = M_PI * Xg2 + 0.5 * (1. - hslope) * sin(2. * M_PI * Xg2) - Xr2;
+		double th_j = poly_norm * ( 2 * Xg2 - 1) * (1 + pow((2 * Xg2 -1)/poly_xt,poly_alpha)/(1+poly_alpha)) + M_PI/2;
+		double Dx1 = Xg1 - startx[1];
+		return th_g + exp(- mks_smooth * Dx1)*(th_j - th_g);
+	}
 }
 
+
 // Returns the value of f'(Xg2).
-double f_primed_Xg2(double Xg2) {
-#if (metric == MKSHARM)
-
-    return M_PI + M_PI * (1. - hslope) * cos(2. * M_PI * Xg2);
-
-#elif (metric == MKSBHAC)
-
-    return 1 + hslope * cos(2. * Xg2);
-
-#endif
-
-    return -1;
+double f_primed_Xg2(double Xg2, double Xg1)
+{
+	if (metric == MKSHARM)
+	{
+		return M_PI + M_PI * (1. - hslope) * cos(2. * M_PI * Xg2);
+	}
+	else if (metric==FMKS2)
+	{
+		double th_gprime = M_PI + M_PI * (1. - hslope) * cos(2. * M_PI * Xg2);
+		double th_jprime = 2 * poly_norm * (1 + pow((2*Xg2 - 1)/poly_xt,poly_alpha));
+		double Dx1 = Xg1 - startx[1];
+		return th_gprime + exp( - mks_smooth *  Dx1)*(th_jprime - th_gprime);
+	}
 }
 
 // This function does "one Newton-Raphson step", i.e. it returns the NEW,
 // "better" estimate Xg2_1 based on the input estimate Xg2_0.
-double NR_stepX(double Xg2_0, double Xr2) {
-    double fprime = f_primed_Xg2(Xg2_0);
+double NR_stepX(double Xg2_0, double Xg1_0, double Xr2)
+{
+	double fprime = f_primed_Xg2(Xg2_0,Xg1_0);
 
-    if (fabs(fprime) < 1.e-9)
-        printf("fprime = %+.15e\n", fprime);
+	if (fabs(fprime) < 1.e-9)
+		printf("fprime = %+.15e\n", fprime);
 
-    return Xg2_0 - f_Xg2(Xg2_0, Xr2) / f_primed_Xg2(Xg2_0);
+	return Xg2_0 - f_Xg2(Xg2_0, Xr2, Xg1_0) / f_primed_Xg2(Xg2_0,Xg1_0);
 }
 
 // Returns the value of f(Ug2) given some value for Ur2. For the correct Ug2,
 // we have f(Ug2) = 0.
-double f_Ug2(double Ug2, double Ur2, double Xg2) {
-#if (metric == MKSHARM)
-
-    return M_PI * Ug2 * (1. + (1. - hslope) * cos(2. * M_PI * Xg2)) - Ur2;
-
-#elif (metric == MKSBHAC)
-
-    return Ug2 * (1. + hslope * cos(2. * Xg2)) - Ur2;
-
-#endif
-
-    return -1;
+double f_Ug2(double Ug2, double Ug1, double Ur2, double Xg2, double Xg1)
+{
+	if (metric == MKSHARM)
+		return M_PI * Ug2 * (1. + (1. - hslope) * cos(2. * M_PI * Xg2)) - Ur2;
+	else if (metric == FMKS2){
+		double th_g = M_PI * Xg2 + 0.5 * (1. - hslope) * sin(2. * M_PI * Xg2);
+		double th_j = poly_norm * ( 2 * Xg2 - 1) * (1 + pow((2 * Xg2 -1)/poly_xt,poly_alpha)/(1+poly_alpha)) + M_PI/2;
+		double th_gprime = M_PI + M_PI * (1. - hslope) * cos(2. * M_PI * Xg2);
+		double th_jprime = 2 * poly_norm * (1 + pow((2*Xg2 - 1)/poly_xt,poly_alpha));
+		double Dx1 = Xg1 - startx[1];
+		double dthdx2 = th_gprime + exp( - mks_smooth * Dx1)*(th_jprime - th_gprime);
+		double dthdx1 = - (mks_smooth) * exp(- mks_smooth * Dx1) * (th_j - th_g);
+		// printf("%lf %lf %lf %lf %lf %lf", Ug2, Ug1, Ur2, Xg2, Xg1, ((dthdx2*Ug2 + dthdx1*Ug1) - Ur2));
+		// exit(-1);
+		return (dthdx2*Ug2 + dthdx1*Ug1) - Ur2;
+	}
 }
 
 // Returns the value of f'(Ug2).
-double f_primed_Ug2(double Ug2, double Xg2) {
-#if (metric == MKSHARM)
-    return M_PI * (1. + (1. - hslope) * cos(2. * M_PI * Xg2));
+double f_primed_Ug2(double Ug2, double Ug1, double Xg2, double Xg1)
+{
+	if (metric == MKSHARM)
+		return M_PI * (1. + (1. - hslope) * cos(2. * M_PI * Xg2));
+	else if (metric == FMKS2){
+		double th_gprimeprime = - 2 * M_PI * M_PI * (1. - hslope) * sin(2. * M_PI * Xg2);
+		double th_jprimeprime = 4 * poly_alpha * poly_norm * pow((2*Xg2 - 1)/poly_xt,poly_alpha-1)/poly_xt;
+		double Dx1 = Xg1 - startx[1];
+		double dsq_th_dx2sq = th_gprimeprime + exp(- mks_smooth * Dx1) * (th_jprimeprime - th_gprimeprime);
+		double th_gprime = M_PI + M_PI * (1. - hslope) * cos(2. * M_PI * Xg2);
+		double th_jprime = 2 * poly_norm * (1 + pow((2*Xg2 - 1)/poly_xt,poly_alpha));
+		double dsq_th_dx1dx2 = - (mks_smooth) * exp(- mks_smooth * Dx1) * (th_jprime - th_gprime);
+		return dsq_th_dx2sq*Ug2 + dsq_th_dx1dx2*Ug1;
+	}
 
-#elif (metric == MKSBHAC)
-
-    return (1. + hslope * cos(2. * Xg2));
-
-#endif
-
-    return -1;
 }
 
 // This function does "one Newton-Raphson step", i.e. it returns the NEW,
 // "better" estimate Ug2_1 based on the input estimate Ug2_0.
-double NR_stepU(double Ug2_0, double Ur2, double Xg2) {
-    double fprime = f_primed_Ug2(Ug2_0, Xg2);
+double NR_stepU(double Ug2_0, double Ug1_0, double Ur2, double Xg2, double Xg1)
+{
+	double fprime = f_primed_Ug2(Ug2_0, Ug1_0, Xg2, Xg1);
 
-    if (fabs(fprime) < 1.e-9)
-        printf("fprime = %+.15e\n", fprime);
+	if (fabs(fprime) < 1.e-9)
+		printf("fprime = %+.15e\n", fprime);
 
-    return Ug2_0 - f_Ug2(Ug2_0, Ur2, Xg2) / f_primed_Ug2(Ug2_0, Xg2);
+	return Ug2_0 - f_Ug2(Ug2_0, Ug1_0, Ur2, Xg2, Xg1) / f_primed_Ug2(Ug2_0, Ug1_0, Xg2, Xg1);
 }
 
 // Given the X2 coordinate in RAPTOR's convention, Xr2, we compute and return
 // an estimate for the corresponding coordinate in HARM2D's convention, Xg2.
-double Xg2_approx_rand(double Xr2) {
-    double Xg2_current = 0.1; // Initial guess; reasonable b/c Xg2 E [0, 1]
-    double Xg2_prev = 1.e-15; // Keeps track of previous estimate to converge
-    double tolerance = 1.e-15; // Maximum error
-    int steps = 0;
-    int maxsteps = 100;
+double Xg2_approx_rand(double Xr2, double Xg1)
+{
+	double Xg2_current = 0.1; // Initial guess; reasonable b/c Xg2 E [0, 1]
+	double Xg2_prev = 1.e-15; // Keeps track of previous estimate to converge
+	double tolerance = 1.e-9; // Maximum error
+	int steps = 0;
+	int maxsteps = 100;
 
-    int count = 0;
+	int count = 0;
 
-    // Main loop
-//    while (fabs(Xg2_current - Xg2_prev) > tolerance) {
-        Xg2_current =  Xr2;//(double)rand() / (double)RAND_MAX;
-        steps = 0;
-        count++;
+	// Main loop
+	while (fabs(Xg2_current - Xg2_prev) > tolerance)
+	{
+		Xg2_current = (double)rand() / (double)RAND_MAX;
+		// Xg2_current = 1.e-16;
+		steps = 0;
+		count++;
 
-        while (steps < maxsteps && fabs(Xg2_current - Xg2_prev) > tolerance) {
-            Xg2_prev = Xg2_current;
-            Xg2_current = NR_stepX(Xg2_current, Xr2);
-            steps++;
-        }
- //   }
+		while (steps < maxsteps && fabs(Xg2_current - Xg2_prev) > tolerance)
+		{
+			Xg2_prev = Xg2_current;
+			Xg2_current = NR_stepX(Xg2_current, Xg1, Xr2);
+			steps++;
+		}
+	}
 
-    // Clamp output value between 0 and 1
-    return Xg2_current;
+	// Clamp output value between 0 and 1
+	return fmin(1., fmax(Xg2_current, 0.));
 }
 
 // Given the U2 coordinate in RAPTOR's convention, Ur2, we compute and return
-// an estimate for the corresponding vector component in HARM2D's convention,
-// Ug2.
-double Ug2_approx_rand(double Ur2, double Xg2) {
-    double Ug2_current = 0.1; // Initial guess; reasonable b/c Xg2 E [0, 1]
-    double Ug2_prev = 1.e-15; // Keeps track of previous estimate to converge
-    double tolerance = 1.e-15; // Maximum error
-    int steps = 0;
-    int maxsteps = 100;
+// an estimate for the corresponding vector component in HARM2D's convention, Ug2.
+double Ug2_approx_rand(double Ur2, double Ug1, double Xg2, double Xg1)
+{
+	double Ug2_current = 0.1; // Initial guess; reasonable b/c Xg2 E [0, 1]
+	double Ug2_prev = 1.e-15; // Keeps track of previous estimate to converge
+	double tolerance = 1.e-9; // Maximum error
+	int steps = 0;
+	int maxsteps = 100;
 
-    int count = 0;
+	int count = 0;
 
-    // Main loop
-//    while (fabs(Ug2_current - Ug2_prev) > tolerance) {
-        Ug2_current = Ur2 ;//(double)rand() / (double)RAND_MAX;
-        steps = 0;
-        count++;
+	// Main loop
+	while (fabs(Ug2_current - Ug2_prev) > tolerance && count<1000)
+	{
+		Ug2_current = (double)rand() / (double)RAND_MAX;
+		steps = 0;
+		count++;
 
-        while (steps < maxsteps && fabs(Ug2_current - Ug2_prev) > tolerance) {
-            Ug2_prev = Ug2_current;
-            Ug2_current = NR_stepU(Ug2_current, Ur2, Xg2);
-            steps++;
-        }
- //   }
-
-    return Ug2_current;
+		while (steps < maxsteps && fabs(Ug2_current - Ug2_prev) > tolerance)
+		{
+			Ug2_prev = Ug2_current;
+			Ug2_current = NR_stepU(Ug2_current, Ug1, Ur2, Xg2, Xg1);
+			steps++;
+			// if (count==1){
+			// 	printf("->%lf ",Ug2_current);
+			// }
+		}
+		// printf("%e \n",Ug2_current);
+	}
+	if (count>=1000){
+		printf("\nUNABLE TO SOLVE FOR U[X2]. EXITING\n");
+		exit(-1);
+	}
+	return Ug2_current;
 }
+


### PR DESCRIPTION
This version of the code is able to image KHARMA/HARM3D grmhd files in FMKS coordinates (https://github.com/AFD-Illinois/docs/wiki/Coordinates#funky-modified-kerr-schild-fmks). Changes were brought about by copying over files from ipole that implement FMKS and do other geometric operations. Since this version is not extensively tested and makes some changes to the source BHAC files (src/metric.c has slight changes), I would recommend pulling it into a new branch exclusively for KHARMA/HARM3D imaging to avoid introducing any bugs to the standard raptor codebase.